### PR TITLE
Fixed rails 4 deprecation warning

### DIFF
--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -1,6 +1,5 @@
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/inquiry"
-require "active_support/core_ext/logger"
 require "active_support/core_ext/module/delegation"
 require "active_support/tagged_logging"
 


### PR DESCRIPTION
DEPRECATION WARNING: this file is deprecated and will be removed. (called from <top (required)> at .../rvm/gems/ruby-2.3.3/bundler/gems/webpacker-a69f26aa9364/lib/webpacker.rb:3)